### PR TITLE
fix: init button selectors broken in latest version of verdaccio

### DIFF
--- a/src/client/verdaccio-4.ts
+++ b/src/client/verdaccio-4.ts
@@ -39,7 +39,7 @@ function updateUsageInfo() {
 }
 
 init({
-  loginButton: "#header--button-login",
-  logoutButton: "#header--button-logout",
+  loginButton: "#header--button-login, [data-testid='header--button-login']",
+  logoutButton: "#header--button-logout, [data-testid='header--button-logout']",
   updateUsageInfo,
 })


### PR DESCRIPTION
Solving a problem from a parent project https://github.com/n4bb12/verdaccio-github-oauth-ui/commit/dd0601a8662cbbb254386dcbc58f50e44086bba4
